### PR TITLE
⚡️ Enable native psycopg3 connection pooling

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -123,6 +123,14 @@ WSGI_APPLICATION = "core.wsgi.application"
 DATABASES = {
     "default": env.db(),
 }
+
+# Native connection pooling (psycopg3 + Django 5.1+).
+# Pooling requires CONN_MAX_AGE to be 0 (persistent connections are
+# managed by the pool, not Django).
+# https://docs.djangoproject.com/en/stable/ref/databases/#connection-pool
+DATABASES["default"]["CONN_MAX_AGE"] = 0
+DATABASES["default"].setdefault("OPTIONS", {})
+DATABASES["default"]["OPTIONS"]["pool"] = True
 # Password validation
 # https://docs.djangoproject.com/en/3.2/ref/settings/#auth-password-validators
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "django-health-check",
     "django-permissions-policy",
     "gunicorn",
-    "psycopg[binary]",
+    "psycopg[binary,pool]",
     "requests",
     "slack-sdk",
     "whitenoise",

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,6 +45,8 @@ psycopg==3.3.4
     # via acronym-slackbot (pyproject.toml)
 psycopg-binary==3.3.4
     # via psycopg
+psycopg-pool==3.3.1
+    # via psycopg
 python-slugify==8.0.4
     # via django-admin-interface
 requests==2.34.2
@@ -55,6 +57,8 @@ sqlparse==0.5.5
     # via django
 text-unidecode==1.3
     # via python-slugify
+typing-extensions==4.15.0
+    # via psycopg-pool
 urllib3==2.7.0
     # via requests
 whitenoise==6.12.0

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ dependencies = [
     { name = "django-permissions-policy" },
     { name = "djangorestframework" },
     { name = "gunicorn" },
-    { name = "psycopg", extra = ["binary"] },
+    { name = "psycopg", extra = ["binary", "pool"] },
     { name = "requests" },
     { name = "slack-sdk" },
     { name = "whitenoise" },
@@ -63,7 +63,7 @@ requires-dist = [
     { name = "gunicorn" },
     { name = "pip-tools", marker = "extra == 'dev'" },
     { name = "prek", marker = "extra == 'dev'" },
-    { name = "psycopg", extras = ["binary"] },
+    { name = "psycopg", extras = ["binary", "pool"] },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "pytest-django", marker = "extra == 'dev'" },
@@ -589,6 +589,9 @@ wheels = [
 binary = [
     { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
 ]
+pool = [
+    { name = "psycopg-pool" },
+]
 
 [[package]]
 name = "psycopg-binary"
@@ -606,6 +609,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/2c/a4981bf42cf30ebba0424971d7ce70a222ae9b82594c42fc3f2105d7b525/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:47f06fcbe8542b4d96d7392c476a74ada521c5aebdb41c3c0155f6595fc14c8d", size = 3944542, upload-time = "2026-02-18T16:52:04.266Z" },
     { url = "https://files.pythonhosted.org/packages/60/e9/b7c29b56aa0b85a4e0c4d89db691c1ceef08f46a356369144430c155a2f5/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7800e6c6b5dc4b0ca7cc7370f770f53ac83886b76afda0848065a674231e856", size = 4254339, upload-time = "2026-02-18T16:52:10.444Z" },
     { url = "https://files.pythonhosted.org/packages/98/5a/291d89f44d3820fffb7a04ebc8f3ef5dda4f542f44a5daea0c55a84abf45/psycopg_binary-3.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:165f22ab5a9513a3d7425ffb7fcc7955ed8ccaeef6d37e369d6cc1dff1582383", size = 3652796, upload-time = "2026-02-18T16:52:14.02Z" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/82/7a23d26039827ecd4ebe93905651029ddd307c5182ad59296dfb6f67b528/psycopg_pool-3.3.1.tar.gz", hash = "sha256:b10b10b7a175d5cc1592147dc5b7eec8a9e0834eb3ed2c4a92c858e2f51eb63c", size = 31661, upload-time = "2026-05-01T23:31:59.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/ed/89c2c620af0e1660354cd8aabf9f5b21f911597ce22acb37c805d6c86bc8/psycopg_pool-3.3.1-py3-none-any.whl", hash = "sha256:2af5b432941c4c9ad5c87b3fa410aec910ec8f7c122855897983a06c45f2e4b5", size = 40023, upload-time = "2026-05-01T23:31:53.136Z" },
 ]
 
 [[package]]
@@ -835,6 +850,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2a/d3/43c2c190bb6b01decc92d87538b451d7fe8070aaaf18aa1e166bf432754e/tryceratops-2.4.1.tar.gz", hash = "sha256:fbfc14650004e27cd1e55ebb7c76b43ced04a4d3b4cbe42aac9d71e4623ed84d", size = 20595, upload-time = "2024-10-30T16:42:40.97Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/b5/88caeba349f17b7fd37b61bc88f81c138b3b5149b4e2a9deec66eaad1bdb/tryceratops-2.4.1-py3-none-any.whl", hash = "sha256:271b92367be89b243918a56361618607d2a9aa4aa4ba766ecfabd5f98c00480c", size = 27378, upload-time = "2024-10-30T16:42:38.914Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements native PostgreSQL connection pooling using Django 5.1+ / psycopg3's built-in pool support, as outlined in [Peterbe's guide](https://www.peterbe.com/plog/native-connection-pooling-django-5-pg).

Fixes #295

## Changes

- **`pyproject.toml`**: add the `pool` extra to psycopg (`psycopg[binary]` → `psycopg[binary,pool]`), pulling in `psycopg_pool`
- **`requirements.txt`**: recompiled via `uv pip compile` (adds `psycopg-pool==3.3.1`)
- **`core/settings.py`**: enable `OPTIONS: {"pool": True}` on the default database and set `CONN_MAX_AGE = 0` (required when pooling — connection lifetime is managed by the pool, not Django)

No PgBouncer or external pooling package is needed; pooling is handled natively by psycopg3.

## Testing

- [x] `uv pip compile` regenerates `requirements.txt` with `psycopg-pool`
- [x] Settings load correctly: `OPTIONS={'pool': True}`, `CONN_MAX_AGE=0`
- [x] Docker stack (`just docker-up`) starts cleanly with the pool enabled — the web container boots and runs migrations through a pooled connection
- [x] All 19 database-dependent tests pass with pooling enabled (`just docker-test`)
- [x] Linting passes (`ruff`, `ruff-format`, `djhtml`, `tryceratops`, `django-upgrade`)

> Note: 7 `DjangoModelInfoTestCase` tests fail **only** in the local docker dev env, which sets `DEBUG=on`. Those tests assert `settings.DEBUG == (app in INSTALLED_APPS)`, but Django forces `DEBUG=False` during test runs while `INSTALLED_APPS` is fixed at import time. GitHub CI runs with `DEBUG=off`, where they pass. This is pre-existing and unrelated to connection pooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)